### PR TITLE
Trending 화면을 SegmentedControl와 PageViewController로 구성하도록 변경

### DIFF
--- a/BetterMVC.xcodeproj/project.pbxproj
+++ b/BetterMVC.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		C1CDF00526BB1A0E00774B41 /* Mintfile in Resources */ = {isa = PBXBuildFile; fileRef = C1CDF00426BB1A0E00774B41 /* Mintfile */; };
 		C1EB857C26BBD19C00CD8987 /* ios-tools in Frameworks */ = {isa = PBXBuildFile; productRef = C1EB857B26BBD19C00CD8987 /* ios-tools */; };
 		C1F6C2BD262AF61900A76943 /* CustomNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F6C2BC262AF61900A76943 /* CustomNavigationController.swift */; };
+		F5FE564E2A39766F00D8EFB6 /* DataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FE564D2A39766F00D8EFB6 /* DataViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +124,7 @@
 		C1CDF00226BB193100774B41 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		C1CDF00426BB1A0E00774B41 /* Mintfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Mintfile; sourceTree = "<group>"; };
 		C1F6C2BC262AF61900A76943 /* CustomNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationController.swift; sourceTree = "<group>"; };
+		F5FE564D2A39766F00D8EFB6 /* DataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -174,6 +176,7 @@
 		C1394F4426816AA200D24CE3 /* Trending */ = {
 			isa = PBXGroup;
 			children = (
+				F5FE564C2A39765600D8EFB6 /* DataViewControllers */,
 				C18BEF4526816D250041977F /* Logic */,
 				C1394F4526816AAF00D24CE3 /* TrendingViewController.swift */,
 				C18BEF4326816C9E0041977F /* TrendingDataSource.swift */,
@@ -363,6 +366,14 @@
 			path = "Custom Views";
 			sourceTree = "<group>";
 		};
+		F5FE564C2A39765600D8EFB6 /* DataViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				F5FE564D2A39766F00D8EFB6 /* DataViewController.swift */,
+			);
+			path = DataViewControllers;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -516,6 +527,7 @@
 				C1615CEB261698590052918D /* ListCollectionViewCell.swift in Sources */,
 				C12849272682DD83001E441D /* EndPoint.swift in Sources */,
 				C1615CCD261696110052918D /* AppDelegate.swift in Sources */,
+				F5FE564E2A39766F00D8EFB6 /* DataViewController.swift in Sources */,
 				C12849252682CF71001E441D /* NetworkSession.swift in Sources */,
 				C14AAAE526BA4E80001418A5 /* EmptyStateView.swift in Sources */,
 				C1A30526261D48C9002DC30F /* LoadingViewController.swift in Sources */,

--- a/BetterMVC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BetterMVC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke.git",
       "state" : {
-        "revision" : "6e6c6b5f8acaaac1ac4f7024dcf40f2facabc0a3",
-        "version" : "9.4.1"
+        "revision" : "7f73ceaeacd5df75a7994cd82e165ad9ff1815db",
+        "version" : "9.6.1"
       }
     }
   ],

--- a/BetterMVC/Activities/Trending/DataViewControllers/DataViewController.swift
+++ b/BetterMVC/Activities/Trending/DataViewControllers/DataViewController.swift
@@ -1,0 +1,77 @@
+//
+//  DataViewController.swift
+//  BetterMVC
+//
+//  Created by Joohee Kim on 2023/06/14.
+//
+
+import UIKit
+
+final class DataViewController: DataLoadingViewController {
+    
+    private let logic = TrendingLogicController()
+
+    private lazy var dataSource = TrendingDataSource(collectionView: collectionView,
+                                                 delegate: self,
+                                                 provider: logic)
+    
+    private lazy var collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.sectionInset = .zero
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        return collectionView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupView()
+    }
+    
+    private func setupView() {
+        view.addSubview(collectionView)
+        collectionView.anchorFillToSuperView()
+        collectionView.dataSource = dataSource
+        collectionView.delegate = dataSource
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        logic.load { [weak self] state in
+            self?.render(state)
+        }
+    }
+    
+    func configure(color: UIColor, time: Time) {
+        collectionView.backgroundColor = color
+        logic.time = time
+    }
+    
+}
+
+private extension DataViewController {
+    private func render(_ state: ViewState<[Movie]>) {
+        switch state {
+        case .loading:
+            showLoadingView()
+        case .presenting:
+            hideLoadingView()
+
+            DispatchQueue.main.async {
+                self.collectionView.reloadData()
+            }
+        case .failed:
+            hideLoadingView()
+        }
+    }
+}
+
+// MARK: - TrendingDataSourceDelegate
+extension DataViewController: TrendingDataSourceDelegate {
+    func moveToDetail(_ movieID: Int) {
+        //
+    }
+    
+}

--- a/BetterMVC/Activities/Trending/Logic/TrendingLogicController.swift
+++ b/BetterMVC/Activities/Trending/Logic/TrendingLogicController.swift
@@ -12,8 +12,10 @@ final class TrendingLogicController {
     private var todayMovies = [Movie]()
     private var thisWeekMovies = [Movie]()
     private let networking = NetworkManager.shared
+    private var hasLoaded: Bool = false
 
     func load(then handler: @escaping (ViewState<[Movie]>) -> Void) {
+        if hasLoaded { return }
         if !todayMovies.isEmpty && !thisWeekMovies.isEmpty {
             switch time {
             case .day:
@@ -37,9 +39,10 @@ final class TrendingLogicController {
                 case .week:
                     self.thisWeekMovies = movies
                 }
-
+                
+                self.hasLoaded = true
                 handler(.presenting(movies))
-            case .failure(let error):
+            case .failure:
                 handler(.failed)
             }
         }

--- a/BetterMVC/Activities/Trending/TrendingDataSource.swift
+++ b/BetterMVC/Activities/Trending/TrendingDataSource.swift
@@ -97,7 +97,7 @@ extension TrendingDataSource: UICollectionViewDelegate {
 // MARK: - UICollectionViewDelegateFlowLayout
 extension TrendingDataSource: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width: CGFloat = (collectionView.frame.width - (16 * 2) - 8) / 2
+        let width: CGFloat = (collectionView.frame.width - 8) / 2
         return .init(width: width, height: 325)
     }
 
@@ -110,7 +110,8 @@ extension TrendingDataSource: UICollectionViewDelegateFlowLayout {
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return .init(top: 16, left: 16, bottom: 16, right: 16)
+//        return .init(top: 16, left: 16, bottom: 16, right: 16)
+        return .zero
     }
 
 }

--- a/BetterMVC/Activities/Trending/TrendingViewController.swift
+++ b/BetterMVC/Activities/Trending/TrendingViewController.swift
@@ -23,13 +23,61 @@ final class TrendingViewController: DataLoadingViewController {
 
     private let logic = TrendingLogicController()
 
-    private lazy var dataSource = TrendingDataSource(collectionView: collectionView,
-                                                 delegate: self,
-                                                 provider: logic)
+//    private lazy var dataSource = TrendingDataSource(collectionView: collectionView,
+//                                                 delegate: self,
+//                                                 provider: logic)
 
     private var segmentedControl: UISegmentedControl?
+    
+    private lazy var firstView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .green
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    private lazy var secondView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .yellow
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
 
-    @IBOutlet private weak var collectionView: UICollectionView!
+//    @IBOutlet private weak var collectionView: UICollectionView!
+    
+    private let vc1: UIViewController = {
+        let vc = UIViewController()
+        vc.view.backgroundColor = .red
+        return vc
+    }()
+    private let vc2: UIViewController = {
+        let vc = UIViewController()
+        vc.view.backgroundColor = .green
+        return vc
+    }()
+    private lazy var pageViewController: UIPageViewController = {
+        let vc = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
+        vc.setViewControllers([self.dataViewControllers[0]], direction: .forward, animated: true)
+        vc.delegate = self
+        vc.dataSource = self
+        vc.view.translatesAutoresizingMaskIntoConstraints = false
+        return vc
+    }()
+    var dataViewControllers: [UIViewController] {
+        [self.vc1, self.vc2]
+      }
+      var currentPage: Int = 0 {
+        didSet {
+          // from segmentedControl -> pageViewController 업데이트
+          print(oldValue, self.currentPage)
+          let direction: UIPageViewController.NavigationDirection = oldValue <= self.currentPage ? .forward : .reverse
+          self.pageViewController.setViewControllers(
+            [dataViewControllers[self.currentPage]],
+            direction: direction,
+            animated: true,
+            completion: nil
+          )
+        }
+      }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -53,33 +101,56 @@ final class TrendingViewController: DataLoadingViewController {
         segmentedControl?.backgroundColor = .secondarySystemBackground
         segmentedControl?.addTarget(self, action: #selector(segmentSelected), for: .valueChanged)
         segmentedControl?.selectedSegmentIndex = 0
-        navigationItem.titleView = segmentedControl
+        segmentedControl?.selectedSegmentTintColor = .label
+        segmentedControl?.setTitleTextAttributes([.foregroundColor: UIColor.systemBackground], for: .selected)
+        segmentedControl?.setTitleTextAttributes([.foregroundColor: UIColor.tertiaryLabel], for: .normal)
+//        navigationItem.titleView = segmentedControl
+        if let segmentedControl {
+            view.addSubview(segmentedControl)
+            segmentedControl.anchor(
+                top: view.safeAreaLayoutGuide.topAnchor,
+                leading: view.leadingAnchor,
+                bottom: nil,
+                trailing: view.trailingAnchor,
+                padding: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16),
+                size: CGSize(width: 0, height: 50)
+            )
+        }
 
         navigationItem.title = "Trending"
-        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationController?.navigationBar.prefersLargeTitles = false
 
-        setupCollectionView()
+//        setupCollectionView()
+//        view.addSubview(pageViewController.view)
+        add(pageViewController)
+        pageViewController.view.anchor(
+            top: view.safeAreaLayoutGuide.topAnchor
+            , leading: view.leadingAnchor
+            , bottom: view.safeAreaLayoutGuide.bottomAnchor
+            , trailing: view.trailingAnchor
+            , padding: UIEdgeInsets(top: 65, left: 16, bottom: 0, right: 16)
+        )
     }
 
     private func setupCollectionView() {
-        collectionView.delegate = dataSource
-        collectionView.dataSource = dataSource
+//        collectionView.delegate = dataSource
+//        collectionView.dataSource = dataSource
     }
 
-    @objc
-    private func segmentSelected(_ sender: UISegmentedControl) {
-        switch sender.selectedSegmentIndex {
-        case SegmentedControl.day.rawValue:
-            logic.time = .day
-        case SegmentedControl.week.rawValue:
-            logic.time = .week
-        default:
-            break
-        }
-
-        logic.load { [weak self] state in
-            self?.render(state)
-        }
+    @objc private func segmentSelected(_ sender: UISegmentedControl) {
+        self.currentPage = sender.selectedSegmentIndex
+//        switch sender.selectedSegmentIndex {
+//        case SegmentedControl.day.rawValue:
+//            logic.time = .day
+//        case SegmentedControl.week.rawValue:
+//            logic.time = .week
+//        default:
+//            break
+//        }
+//
+//        logic.load { [weak self] state in
+//            self?.render(state)
+//        }
     }
 
 }
@@ -93,13 +164,11 @@ private extension TrendingViewController {
         case .presenting:
             hideLoadingView()
 
-            DispatchQueue.main.async {
-                self.collectionView.reloadData()
-            }
+//            DispatchQueue.main.async {
+//                self.collectionView.reloadData()
+//            }
         case .failed:
             hideLoadingView()
-
-            print("Failed to load")
         }
     }
 }
@@ -109,5 +178,47 @@ extension TrendingViewController: TrendingDataSourceDelegate {
     func moveToDetail(_ movieID: Int) {
         let detailVC = DetailViewController.initialize(with: movieID)
         navigationController?.pushViewController(detailVC, animated: true)
+    }
+}
+
+// MARK: - UIPageViewControllerDelegate
+extension TrendingViewController: UIPageViewControllerDelegate {
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        didFinishAnimating finished: Bool,
+        previousViewControllers: [UIViewController],
+        transitionCompleted completed: Bool
+    ) {
+        guard
+            let viewController = pageViewController.viewControllers?[0],
+            let index = self.dataViewControllers.firstIndex(of: viewController)
+        else { return }
+        self.currentPage = index
+        self.segmentedControl?.selectedSegmentIndex = index
+    }
+}
+
+// MARK: - UIPageViewControllerDataSource
+extension TrendingViewController: UIPageViewControllerDataSource {
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        viewControllerBefore viewController: UIViewController
+    ) -> UIViewController? {
+        guard
+            let index = self.dataViewControllers.firstIndex(of: viewController),
+            index - 1 >= 0
+        else { return nil }
+        return self.dataViewControllers[index - 1]
+    }
+    
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        viewControllerAfter viewController: UIViewController
+    ) -> UIViewController? {
+        guard
+            let index = self.dataViewControllers.firstIndex(of: viewController),
+            index + 1 < self.dataViewControllers.count
+        else { return nil }
+        return self.dataViewControllers[index + 1]
     }
 }

--- a/BetterMVC/Activities/Trending/TrendingViewController.swift
+++ b/BetterMVC/Activities/Trending/TrendingViewController.swift
@@ -21,39 +21,14 @@ final class TrendingViewController: DataLoadingViewController {
         }
     }
 
-    private let logic = TrendingLogicController()
-
+//    private let logic = TrendingLogicController()
+//
 //    private lazy var dataSource = TrendingDataSource(collectionView: collectionView,
 //                                                 delegate: self,
 //                                                 provider: logic)
 
     private var segmentedControl: UISegmentedControl?
     
-    private lazy var firstView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .green
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-    private lazy var secondView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .yellow
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-
-//    @IBOutlet private weak var collectionView: UICollectionView!
-    
-    private let vc1: UIViewController = {
-        let vc = UIViewController()
-        vc.view.backgroundColor = .red
-        return vc
-    }()
-    private let vc2: UIViewController = {
-        let vc = UIViewController()
-        vc.view.backgroundColor = .green
-        return vc
-    }()
     private lazy var pageViewController: UIPageViewController = {
         let vc = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
         vc.setViewControllers([self.dataViewControllers[0]], direction: .forward, animated: true)
@@ -62,33 +37,35 @@ final class TrendingViewController: DataLoadingViewController {
         vc.view.translatesAutoresizingMaskIntoConstraints = false
         return vc
     }()
+    private lazy var todayViewController: DataViewController = DataViewController()
+    private lazy var weekViewController: DataViewController = DataViewController()
     var dataViewControllers: [UIViewController] {
-        [self.vc1, self.vc2]
-      }
-      var currentPage: Int = 0 {
+        [todayViewController, weekViewController]
+    }
+    var currentPage: Int = 0 {
         didSet {
-          // from segmentedControl -> pageViewController 업데이트
-          print(oldValue, self.currentPage)
-          let direction: UIPageViewController.NavigationDirection = oldValue <= self.currentPage ? .forward : .reverse
-          self.pageViewController.setViewControllers(
-            [dataViewControllers[self.currentPage]],
-            direction: direction,
-            animated: true,
-            completion: nil
-          )
+            // from segmentedControl -> pageViewController 업데이트
+            print(oldValue, self.currentPage)
+            let direction: UIPageViewController.NavigationDirection = oldValue <= self.currentPage ? .forward : .reverse
+            self.pageViewController.setViewControllers(
+                [dataViewControllers[self.currentPage]],
+                direction: direction,
+                animated: true,
+                completion: nil
+            )
         }
-      }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         setupView()
 
-        render(.loading)
+//        render(.loading)
 
-        logic.load { [weak self] state in
-            self?.render(state)
-        }
+//        logic.load { [weak self] state in
+//            self?.render(state)
+//        }
     }
 
     private func setupView() {
@@ -122,6 +99,9 @@ final class TrendingViewController: DataLoadingViewController {
 
 //        setupCollectionView()
 //        view.addSubview(pageViewController.view)
+        todayViewController.configure(color: .systemBackground, time: .day)
+        weekViewController.configure(color: .systemBackground, time: .week)
+        
         add(pageViewController)
         pageViewController.view.anchor(
             top: view.safeAreaLayoutGuide.topAnchor

--- a/BetterMVC/Base.lproj/Main.storyboard
+++ b/BetterMVC/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gJ5-38-UVb">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gJ5-38-UVb">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -54,7 +54,7 @@
                     <tabBarItem key="tabBarItem" title="Discover" image="lasso.sparkles" catalog="system" id="vJ2-sR-Jpk"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="iLY-7b-gMO">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -95,7 +95,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Dah-0h-knf">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="UMz-la-Yja">
                                     <size key="itemSize" width="128" height="128"/>
@@ -131,32 +131,10 @@
                     <view key="view" contentMode="scaleToFill" id="alf-yK-PlL">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="mrT-cY-coF">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="E5p-IQ-S20">
-                                    <size key="itemSize" width="128" height="128"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells/>
-                            </collectionView>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="ZVR-rg-twa"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="ZVR-rg-twa" firstAttribute="trailing" secondItem="mrT-cY-coF" secondAttribute="trailing" id="07m-eq-ZKF"/>
-                            <constraint firstItem="mrT-cY-coF" firstAttribute="top" secondItem="alf-yK-PlL" secondAttribute="top" id="HMu-M7-Bdl"/>
-                            <constraint firstItem="mrT-cY-coF" firstAttribute="leading" secondItem="ZVR-rg-twa" secondAttribute="leading" id="WXa-Zo-fqk"/>
-                            <constraint firstItem="ZVR-rg-twa" firstAttribute="bottom" secondItem="mrT-cY-coF" secondAttribute="bottom" id="w8Y-OE-pHN"/>
-                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Q9I-ZI-YyL"/>
-                    <connections>
-                        <outlet property="collectionView" destination="mrT-cY-coF" id="b3K-aN-9iQ"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LjF-nM-N2a" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -169,7 +147,7 @@
                     <tabBarItem key="tabBarItem" title="Favorites" image="star.fill" catalog="system" id="VRc-dO-9jR"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="jPd-aO-XE7">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -188,7 +166,7 @@
                     <tabBarItem key="tabBarItem" title="Trending" image="bubble.left.and.bubble.right" catalog="system" id="i9b-bf-fr0"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="N0R-qD-hh0">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -203,7 +181,7 @@
     </scenes>
     <resources>
         <image name="bubble.left.and.bubble.right" catalog="system" width="128" height="96"/>
-        <image name="lasso.sparkles" catalog="system" width="122" height="128"/>
+        <image name="lasso.sparkles" catalog="system" width="115" height="128"/>
         <image name="star.fill" catalog="system" width="128" height="116"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
SegmentedControl를 타이틀뷰에 사용하는데, PageViewController랑 조합해서 나타나는 화면으로 변경

| Today, Light Mode | This Week, Dark Mode |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-06-14 at 13 52 06](https://github.com/imjhk03/BetterMVC/assets/28954046/9a972b05-11ae-4332-9b4a-1853f0abee2a) | ![Simulator Screenshot - iPhone 14 Pro - 2023-06-14 at 13 52 14](https://github.com/imjhk03/BetterMVC/assets/28954046/7b446ee1-1b0f-492b-acbd-5c5dd67b4e2e) | 

close #13 

참고
[[iOS - swift] 1. UISegmentedControl - 기본 사용 방법](https://ios-development.tistory.com/962)
[[iOS - swift] 2. UISegmentedControl - 커스텀 방법, PageViewController와 사용 방법](https://ios-development.tistory.com/963)